### PR TITLE
Create include.xml

### DIFF
--- a/include.xml
+++ b/include.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<extension>
+	
+	<haxedef name="HXCPP_TELEMETRY" if="cpp" />
+	<haxedef name="HXCPP_STACK_TRACE" if="cpp" />
+	
+</extension>


### PR DESCRIPTION
I've integrated an initial go of hxtelemetry support in OpenFL :smile:

https://github.com/openfl/openfl/commit/1601be4518a9151162cc1989e82c0fcfa1b8ce2b

If the user defines "telemetry" or "advanced-telemetry" it should include the hxtelemetry haxelib when targeting C++ targets.

``` bash
openfl test windows -Dtelemetry
```

In order to make hxtelemetry work on C++, I understand you need an additional two defines when compiling. This pull should allow these to be added automatically when a user has the hxtelemetry library included with an OpenFL project
