### PR TITLE
Add string encoding argument for Haxe 4

### DIFF
--- a/hxtelemetry/CppHxTelemetry.hx
+++ b/hxtelemetry/CppHxTelemetry.hx
@@ -114,7 +114,11 @@ if (!(frame==0 || output==null())) {
       while (i<size) {
         String s = String(frame->names->at(i++));
         output->writeInt32(s.length);
+        #if (HXCPP_API_LEVEL>=400)
+        output->writeString(s, null());
+        #else
         output->writeString(s);
+        #endif
       }
     }
 


### PR DESCRIPTION
Presumably this fix will cause compilation to break for anybody using a Haxe 4.0.0 version from prior to https://github.com/HaxeFoundation/haxe/commit/03659011fc92ffd754a75d78b251d0a4e5724a72. I'm not sure if there's a define that could be used in place of `#if (HXCPP_API_LEVEL>=400)` that would make this work for them, too.